### PR TITLE
Added fallback solution in case linux fails to set the audio-buffer-size

### DIFF
--- a/Backends/Linux/Sources/Kore/Sound.cpp
+++ b/Backends/Linux/Sources/Kore/Sound.cpp
@@ -102,7 +102,7 @@ namespace {
         }
 
         snd_pcm_uframes_t bufferSize = rate / 8;
-        if ((err = snd_pcm_hw_params_set_buffer_size(playback_handle, hw_params, bufferSize)) < 0) {
+        if (((err = snd_pcm_hw_params_set_buffer_size(playback_handle, hw_params, bufferSize)) < 0 && (snd_pcm_hw_params_set_buffer_size_near(playback_handle, hw_params, &bufferSize)) < 0)) {
             fprintf (stderr, "cannot set buffer size (%s)\n",
                  snd_strerror (err));
             exit (1);


### PR DESCRIPTION
 Added fallback solution in case linux fails to set the audio-buffer-size to the requested Value of 44100 Hz.
Fallback chooses the nearest possible value.
