### PR TITLE
Changed iOS AVAudioSessionCategory to AVAudioSessionCategoryAmbient

### DIFF
--- a/Backends/System/iOS/Sources/kinc/backend/KoreAppDelegate.m.h
+++ b/Backends/System/iOS/Sources/kinc/backend/KoreAppDelegate.m.h
@@ -1,6 +1,7 @@
 #import "GLView.h"
 #import "GLViewController.h"
 #import "KoreAppDelegate.h"
+#import <AVFAudio/AVFAudio.h>
 
 #include <kinc/system.h>
 #include <wchar.h>
@@ -31,6 +32,13 @@ void loadURL(const char *url) {
 }
 
 - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
+    AVAudioSession *sessionInstance = [AVAudioSession sharedInstance];
+        NSError *error;
+        
+        // set the session category
+    NSString *category = AVAudioSessionCategoryAmbient;
+        bool success = [sessionInstance setCategory:category error:&error];
+        if (!success) NSLog(@"Error setting AVAudioSession category! %@\n", [error localizedDescription]);
 	// CGRect rect = [[UIScreen mainScreen] applicationFrame];
 	// CGRect screenBounds = [[UIScreen mainScreen] bounds];
 


### PR DESCRIPTION
By default, the audio session category for an iOS app is set to "AmbientSolo", which stops background audio from playing. This pull request changes the audio session category to "Ambient", which acts the same as AmbientSolo but allows background audio to play.

The android target already works in the same way, so I figure I might as well provide some extra parity.

More info [here](https://developer.apple.com/documentation/avfaudio/avaudiosessioncategory?language=objc)