### PR TITLE
Replacement of the metal device's library creation

### DIFF
--- a/backends/gpu/metal/sources/device.m
+++ b/backends/gpu/metal/sources/device.m
@@ -130,7 +130,6 @@ void kore_metal_device_create(kore_gpu_device *device, const kore_gpu_device_wis
 	}
 
 	device->metal.device  = (__bridge_retained void *)metal_device;
-	device->metal.library = (__bridge_retained void *)[metal_device newDefaultLibrary];
 
 	create_execution_fence(device);
 }

--- a/backends/gpu/metal/sources/device.m
+++ b/backends/gpu/metal/sources/device.m
@@ -129,9 +129,7 @@ void kore_metal_device_create(kore_gpu_device *device, const kore_gpu_device_wis
 		metal_device = MTLCreateSystemDefaultDevice();
 	}
 
-	device->metal.device  = (__bridge_retained void *)metal_device;
-	device->metal.library = (__bridge_retained void *)[metal_device newDefaultLibrary];
-
+	device->metal.device = (__bridge_retained void *)metal_device;
 	create_execution_fence(device);
 }
 

--- a/backends/gpu/metal/sources/device.m
+++ b/backends/gpu/metal/sources/device.m
@@ -129,7 +129,9 @@ void kore_metal_device_create(kore_gpu_device *device, const kore_gpu_device_wis
 		metal_device = MTLCreateSystemDefaultDevice();
 	}
 
-	device->metal.device = (__bridge_retained void *)metal_device;
+	device->metal.device  = (__bridge_retained void *)metal_device;
+	device->metal.library = (__bridge_retained void *)[metal_device newDefaultLibrary];
+
 	create_execution_fence(device);
 }
 

--- a/backends/gpu/metal/sources/device.m
+++ b/backends/gpu/metal/sources/device.m
@@ -130,7 +130,6 @@ void kore_metal_device_create(kore_gpu_device *device, const kore_gpu_device_wis
 	}
 
 	device->metal.device  = (__bridge_retained void *)metal_device;
-
 	create_execution_fence(device);
 }
 

--- a/backends/gpu/metal/sources/pipeline.m
+++ b/backends/gpu/metal/sources/pipeline.m
@@ -146,7 +146,8 @@ void kore_metal_render_pipeline_init(kore_metal_device *device, kore_metal_rende
 	id<MTLLibrary> library = (__bridge id<MTLLibrary>)device->library;
 
 	if(library == nil) {
-		device->library = (__bridge_retained void *)[device->device newDefaultLibrary];
+		id<MTLDevice> metal_device = (__bridge id<MTLDevice>)device->device;
+		device->library = (__bridge_retained void *)[metal_device newDefaultLibrary];
 		library = (__bridge id<MTLLibrary>)device->library;
 	}
 

--- a/backends/gpu/metal/sources/pipeline.m
+++ b/backends/gpu/metal/sources/pipeline.m
@@ -145,6 +145,11 @@ static MTLCompareFunction convert_compare(kore_gpu_compare_function func) {
 void kore_metal_render_pipeline_init(kore_metal_device *device, kore_metal_render_pipeline *pipe, const kore_metal_render_pipeline_parameters *parameters) {
 	id<MTLLibrary> library = (__bridge id<MTLLibrary>)device->library;
 
+	if(library == nil) {
+		device->library = (__bridge_retained void *)[device->device newDefaultLibrary];
+		library = (__bridge id<MTLLibrary>)device->library;
+	}
+
 	id vertex_function   = [library newFunctionWithName:[NSString stringWithCString:parameters->vertex.shader.function_name encoding:NSUTF8StringEncoding]];
 	id fragment_function = [library newFunctionWithName:[NSString stringWithCString:parameters->fragment.shader.function_name encoding:NSUTF8StringEncoding]];
 


### PR DESCRIPTION
I moved `newDefaultLibrary` from `kore_metal_device_create` to `kore_metal_render_pipeline_init` to allow for the addition of a custom library creation function.